### PR TITLE
DI-1801 Consider transcript and use HGVSc or HGSVp to extract inframe deletion positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This script generates counts of how many unique patients each variant is present
 - The number of patients with inframe deletions which cover the same CDS positions or are nested within the deletion.
     - These counts are only present for the `In_Frame_Del` variant type.
 
-This requires a file (`--columns_to_aggregate.txt`) where each Genie annotation to be kept in the final VCF are provided, one per line. A file of cancer types which are classified as haemonc-related cancer types are (`--haemonc_cancer_types.txt`) and a file of cancer types which are classified as solid cancer types (`--solid_cancer_types.txt`) can also be provided in order to generate grouped counts.
+This requires a file (`--columns_to_aggregate.txt`) where each Genie annotation to be kept in the final VCF are provided, one per line, and (`--column_for_inframe_deletions`) which specifies whether to extract positions of an inframe deletion from the HGVSc or HGVSp notation. A file of cancer types which are classified as haemonc-related cancer types are (`--haemonc_cancer_types.txt`) and a file of cancer types which are classified as solid cancer types (`--solid_cancer_types.txt`) can also be provided in order to generate grouped counts.
 
 Example command:
 ```
@@ -183,6 +183,7 @@ python generate_count_data.py \
   --columns_to_aggregate columns_to_aggregate.txt \
   --haemonc_cancer_types haemonc_cancer_types.txt (optional) \
   --solid_cancer_types solid_cancer_types.txt (optional) \
+  --column_for_inframe_deletions HGVSp [HGVSc or HGVSp] \
   --output Genie_v17_GRCh38_counts.tsv
 ```
 

--- a/generate_count_data.py
+++ b/generate_count_data.py
@@ -14,13 +14,13 @@ from utils.aggregation import (
     get_inframe_deletions,
 )
 from utils.counting import (
-    add_deletion_positions,
     count_same_nucleotide_change,
     count_same_nucleotide_change_per_cancer_type,
     count_amino_acid_change,
     count_amino_acid_change_per_cancer_type,
     count_frameshift_truncating_and_nonsense,
     count_frameshift_truncating_and_nonsense_per_cancer_type,
+    add_deletion_positions,
     extract_position_from_hgvsc,
     count_nested_inframe_deletions,
     count_nested_inframe_deletions_per_cancer_type,

--- a/generate_count_data.py
+++ b/generate_count_data.py
@@ -99,6 +99,10 @@ def main():
     columns_to_aggregate = read_txt_file_to_list(args.columns_to_aggregate)
 
     deletion_source = args.column_for_inframe_deletions
+    if deletion_source == "HGVSc":
+        inframe_naming = "CDS"
+    else:
+        inframe_naming = "AA"
     haemonc_cancers = solid_cancers = None
     if args.haemonc_cancer_types:
         haemonc_cancers = read_txt_file_to_list(args.haemonc_cancer_types)
@@ -184,14 +188,7 @@ def main():
         f"{datetime.now().replace(microsecond=0)} Generating truncating"
         " variant counts"
     )
-    truncating_variants = get_truncating_variants(genie_data).select(
-        "Hugo_Symbol",
-        "grch38_description",
-        "Transcript_ID",
-        "HGVSc",
-        "PATIENT_ID",
-        "CANCER_TYPE",
-    )
+    truncating_variants = get_truncating_variants(genie_data)
     truncating_variants = extract_position_from_hgvsc(truncating_variants)
 
     truncating_counts_all_cancers = count_frameshift_truncating_and_nonsense(
@@ -219,13 +216,6 @@ def main():
     )
     inframe_deletions = get_inframe_deletions(
         df=genie_data, column_used=deletion_source
-    ).select(
-        "grch38_description",
-        "Hugo_Symbol",
-        "Transcript_ID",
-        deletion_source,
-        "PATIENT_ID",
-        "CANCER_TYPE",
     )
     inframe_deletions = add_deletion_positions(
         inframe_deletions, source=deletion_source
@@ -234,15 +224,15 @@ def main():
         inframe_deletions_df=inframe_deletions,
         cancer_count_type="All_Cancers",
         patient_total=patient_total,
+        position_method=inframe_naming,
     )
-
     inframe_deletions_count_per_cancer = (
         count_nested_inframe_deletions_per_cancer_type(
             inframe_deletions_df=inframe_deletions,
             per_cancer_patient_total=per_cancer_patient_total,
+            position_method=inframe_naming,
         )
     )
-
     inframe_deletions_with_counts = merge_inframe_deletions_with_counts(
         inframe_deletions_with_positions=inframe_deletions,
         inframe_deletions_count_all_cancers=inframe_deletions_count_all_cancers,
@@ -326,12 +316,6 @@ def main():
 
         inframe_deletions_haemonc = get_inframe_deletions(
             df=haemonc_rows, column_used=deletion_source
-        ).select(
-            "Hugo_Symbol",
-            "grch38_description",
-            "Transcript_ID",
-            deletion_source,
-            "PATIENT_ID",
         )
         inframe_deletions_haemonc = add_deletion_positions(
             inframe_deletions_haemonc, source=deletion_source
@@ -342,6 +326,7 @@ def main():
                 cancer_count_type="Haemonc_Cancers",
                 patient_total=haemonc_cancer_patient_total,
                 inframe_deletions=inframe_deletions,
+                position_method=inframe_naming,
             )
         )
 
@@ -353,23 +338,14 @@ def main():
 
         all_ho_counts = all_ho_counts.join(
             frameshift_counts_haemonc,
-            on=["Hugo_Symbol", "grch38_description"],
+            on="grch38_description",
             how="left",
         )
 
         all_ho_counts = all_ho_counts.join(
             inframe_deletions_count_haemonc_cancers,
-            on=["Hugo_Symbol", "grch38_description"],
+            on="grch38_description",
             how="left",
-        )
-
-        all_ho_counts = all_ho_counts.drop(
-            "Hugo_Symbol",
-            "HGVSp",
-            "Transcript_ID",
-            "del_start",
-            "del_end",
-            "CDS_position",
         )
 
         one_row_per_variant_agg = one_row_per_variant_agg.join(
@@ -423,11 +399,6 @@ def main():
 
         inframe_deletions_solid = get_inframe_deletions(
             df=solid_rows, column_used=deletion_source
-        ).select(
-            "Hugo_Symbol",
-            "grch38_description",
-            deletion_source,
-            "PATIENT_ID",
         )
         inframe_deletions_solid = add_deletion_positions(
             inframe_deletions_solid, source=deletion_source
@@ -437,6 +408,7 @@ def main():
             cancer_count_type="Solid_Cancers",
             patient_total=solid_cancer_patient_total,
             inframe_deletions=inframe_deletions,
+            position_method=inframe_naming,
         )
 
         all_solid_counts = nucleotide_counts_solid_cancers.join(
@@ -447,22 +419,14 @@ def main():
 
         all_solid_counts = all_solid_counts.join(
             frameshift_counts_solid,
-            on=["Hugo_Symbol", "grch38_description"],
+            on="grch38_description",
             how="left",
         )
 
         all_solid_counts = all_solid_counts.join(
             inframe_deletions_count_solid_cancers,
-            on=["Hugo_Symbol", "grch38_description"],
+            on="grch38_description",
             how="left",
-        )
-
-        all_solid_counts = all_solid_counts.drop(
-            "Hugo_Symbol",
-            "HGVSp",
-            "del_start",
-            "del_end",
-            "CDS_position",
         )
 
         one_row_per_variant_agg = one_row_per_variant_agg.join(
@@ -479,6 +443,7 @@ def main():
         per_cancer_patient_total,
         haemonc_cancer_patient_total,
         solid_cancer_patient_total,
+        inframe_naming,
     )
 
     final_df.write_csv(

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -125,7 +125,7 @@ class TestGetTruncatingVariants:
 
 
 class TestGetInframeDeletions:
-    def test_get_inframe_deletions_filters_correctly(self):
+    def test_get_inframe_deletions_filters_correctly_hgvsc(self):
         df = pl.DataFrame(
             {
                 "Variant_Classification": [
@@ -136,12 +136,35 @@ class TestGetInframeDeletions:
                 "HGVSc": ["c.123del", None, "c.456A>T"],
             }
         )
-        result = get_inframe_deletions(df)
+        result = get_inframe_deletions(df, column_used="HGVSc")
 
         expected = pl.DataFrame(
             {
                 "Variant_Classification": ["In_Frame_Del"],
                 "HGVSc": ["c.123del"],
+            }
+        )
+        assert_frame_equal(
+            result, expected, check_column_order=False, check_row_order=False
+        )
+
+    def test_get_inframe_deletions_filters_correctly_hgvsp(self):
+        df = pl.DataFrame(
+            {
+                "Variant_Classification": [
+                    "In_Frame_Del",
+                    "In_Frame_Del",
+                    "Missense_Mutation",
+                ],
+                "HGVSp": ["p.His42dup", None, "p.His41_His42dup"],
+            }
+        )
+        result = get_inframe_deletions(df, column_used="HGVSp")
+
+        expected = pl.DataFrame(
+            {
+                "Variant_Classification": ["In_Frame_Del"],
+                "HGVSp": ["p.His42dup"],
             }
         )
         assert_frame_equal(

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -91,11 +91,27 @@ class TestGetTruncatingVariants:
     def test_get_truncating_variants_filters_correctly(self):
         df = pl.DataFrame(
             {
+                "grch38_description": [
+                    "var1",
+                    "var2",
+                    "var3",
+                    "var4",
+                ],
+                "Hugo_Symbol": ["TP53", "BRCA1", "EGFR", "PTEN"],
+                "Transcript_ID": ["tx1", "tx2", "tx3", "tx4"],
+                "PATIENT_ID": [1, 2, 3, 4],
+                "CANCER_TYPE": ["Lung", "Breast", "Colon", "Prostate"],
                 "Variant_Classification": [
                     "Frame_Shift_Del",
                     "Frame_Shift_Ins",
                     "Nonsense_Mutation",
                     "Missense_Mutation",
+                ],
+                "HGVSc": [
+                    "c.67del",
+                    "c.149dup",
+                    "c.298C>T",
+                    "c.300G>C",
                 ],
                 "HGVSp": [
                     "p.Trp23Ter",
@@ -110,12 +126,12 @@ class TestGetTruncatingVariants:
 
         expected = pl.DataFrame(
             {
-                "Variant_Classification": [
-                    "Frame_Shift_Del",
-                    "Frame_Shift_Ins",
-                    "Nonsense_Mutation",
-                ],
-                "HGVSp": ["p.Trp23Ter", "p.Arg50Ter", "p.StopTer"],
+                "grch38_description": ["var1", "var2", "var3"],
+                "Hugo_Symbol": ["TP53", "BRCA1", "EGFR"],
+                "Transcript_ID": ["tx1", "tx2", "tx3"],
+                "PATIENT_ID": [1, 2, 3],
+                "CANCER_TYPE": ["Lung", "Breast", "Colon"],
+                "HGVSc": ["c.67del", "c.149dup", "c.298C>T"],
             }
         )
 
@@ -128,6 +144,15 @@ class TestGetInframeDeletions:
     def test_get_inframe_deletions_filters_correctly_hgvsc(self):
         df = pl.DataFrame(
             {
+                "grch38_description": [
+                    "var1",
+                    "var2",
+                    "var3",
+                ],
+                "Hugo_Symbol": ["TP53", "BRCA1", "EGFR"],
+                "Transcript_ID": ["tx1", "tx2", "tx3"],
+                "PATIENT_ID": [1, 2, 3],
+                "CANCER_TYPE": ["Lung", "Breast", "Colon"],
                 "Variant_Classification": [
                     "In_Frame_Del",
                     "In_Frame_Del",
@@ -140,7 +165,11 @@ class TestGetInframeDeletions:
 
         expected = pl.DataFrame(
             {
-                "Variant_Classification": ["In_Frame_Del"],
+                "grch38_description": ["var1"],
+                "Hugo_Symbol": ["TP53"],
+                "Transcript_ID": ["tx1"],
+                "PATIENT_ID": [1],
+                "CANCER_TYPE": ["Lung"],
                 "HGVSc": ["c.123del"],
             }
         )
@@ -151,6 +180,15 @@ class TestGetInframeDeletions:
     def test_get_inframe_deletions_filters_correctly_hgvsp(self):
         df = pl.DataFrame(
             {
+                "grch38_description": [
+                    "var1",
+                    "var2",
+                    "var3",
+                ],
+                "Hugo_Symbol": ["TP53", "BRCA1", "EGFR"],
+                "Transcript_ID": ["tx1", "tx2", "tx3"],
+                "PATIENT_ID": [1, 2, 3],
+                "CANCER_TYPE": ["Lung", "Breast", "Colon"],
                 "Variant_Classification": [
                     "In_Frame_Del",
                     "In_Frame_Del",
@@ -163,7 +201,11 @@ class TestGetInframeDeletions:
 
         expected = pl.DataFrame(
             {
-                "Variant_Classification": ["In_Frame_Del"],
+                "grch38_description": ["var1"],
+                "Hugo_Symbol": ["TP53"],
+                "Transcript_ID": ["tx1"],
+                "PATIENT_ID": [1],
+                "CANCER_TYPE": ["Lung"],
                 "HGVSp": ["p.His42dup"],
             }
         )

--- a/tests/test_counting.py
+++ b/tests/test_counting.py
@@ -524,84 +524,6 @@ class TestExtractPositionFromHGVSc:
         )
 
 
-class TestCountPatientsWithVariantAtSamePositionOrDownstream:
-    def test_count_downstream(self):
-        df = pl.from_dict(
-            {
-                "Hugo_Symbol": [
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                ],
-                "CDS_position": [
-                    480,
-                    481,
-                    481,
-                    483,
-                    484,
-                    485,
-                    511,
-                    512,
-                    513,
-                    514,
-                ],
-                "PATIENT_ID": [
-                    "patient_1",
-                    "patient_1",
-                    "patient_2",
-                    "patient_3",
-                    "patient_4",
-                    "patient_5",
-                    "patient_5",
-                    "patient_6",
-                    "patient_7",
-                    "patient_8",
-                ],
-            }
-        )
-
-        result = utils.counting.count_downstream(df)
-
-        expected = pl.from_dict(
-            {
-                "Hugo_Symbol": [
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                ],
-                "CDS_position": [
-                    480,
-                    481,
-                    483,
-                    484,
-                    485,
-                    511,
-                    512,
-                    513,
-                    514,
-                ],
-                "downstream_patient_count": [8, 8, 6, 5, 4, 4, 3, 2, 1],
-            }
-        )
-
-        assert_frame_equal(
-            result, expected, check_column_order=False, check_row_order=False
-        )
-
-
 class TestCountFrameshiftTruncatingAndNonsenseInCancers:
     def test_count_frameshift_truncating_and_nonsense(self):
         df = pl.from_dict(
@@ -615,6 +537,15 @@ class TestCountFrameshiftTruncatingAndNonsenseInCancers:
                     "GENE1",
                     "GENE1",
                 ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript2",
+                ],
                 "CDS_position": [
                     480,
                     481,
@@ -631,7 +562,7 @@ class TestCountFrameshiftTruncatingAndNonsenseInCancers:
                     "patient_3",
                     "patient_4",
                     "patient_5",
-                    "patient_5",
+                    "patient_1",
                 ],
             }
         )
@@ -650,13 +581,21 @@ class TestCountFrameshiftTruncatingAndNonsenseInCancers:
                     "GENE1",
                     "GENE1",
                 ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript2",
+                ],
                 "CDS_position": [480, 481, 483, 484, 485, 511],
                 "SameOrDownstreamTruncatingVariantsPerCDS.All_Cancers_Count_N_500": [
-                    5,
-                    5,
-                    3,
+                    4,
+                    4,
                     2,
                     1,
+                    2,
                     1,
                 ],
             }
@@ -679,6 +618,15 @@ class TestCountFrameshiftTruncatingAndNonsensePerCancerType:
                     "GENE1",
                     "GENE1",
                     "GENE1",
+                ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript2",
                 ],
                 "CDS_position": [
                     480,
@@ -732,6 +680,14 @@ class TestCountFrameshiftTruncatingAndNonsensePerCancerType:
                     "GENE1",
                     "GENE1",
                 ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript2",
+                ],
                 "CDS_position": [480, 481, 483, 484, 485, 511],
                 "SameOrDownstreamTruncatingVariantsPerCDS.Cancer 1_Count_N_500": [
                     2,
@@ -742,10 +698,10 @@ class TestCountFrameshiftTruncatingAndNonsensePerCancerType:
                     0,
                 ],
                 "SameOrDownstreamTruncatingVariantsPerCDS.Cancer 2_Count_N_4": [
-                    2,
-                    2,
                     1,
                     1,
+                    0,
+                    0,
                     1,
                     1,
                 ],
@@ -758,10 +714,10 @@ class TestCountFrameshiftTruncatingAndNonsensePerCancerType:
                     0,
                 ],
                 "SameOrDownstreamTruncatingVariantsPerCDS.Cancer 4_Count_N_50": [
-                    2,
-                    2,
-                    2,
                     1,
+                    1,
+                    1,
+                    0,
                     1,
                     0,
                 ],
@@ -781,8 +737,8 @@ class TestCountFrameshiftTruncatingAndNonsensePerCancerType:
         )
 
 
-class TestExtractHGVScDeletionPositions:
-    def test_add_deletion_positions(self):
+class TestAddDeletionPositions:
+    def test_add_deletion_positions_hgvsc(self):
         df = pl.from_dict(
             {
                 "HGVSc": [
@@ -792,7 +748,7 @@ class TestExtractHGVScDeletionPositions:
                 ]
             }
         )
-        result = utils.counting.add_deletion_positions(df)
+        result = utils.counting.add_deletion_positions(df, source="HGVSc")
         expected = pl.from_dict(
             {
                 "HGVSc": [
@@ -808,63 +764,37 @@ class TestExtractHGVScDeletionPositions:
             result, expected, check_column_order=False, check_row_order=False
         )
 
-
-class TestCountPatientsWithNestedDeletions:
-    def test_count_patients_with_nested_deletions(self):
+    def test_add_deletion_positions_hgvsp(self):
         df = pl.from_dict(
             {
-                "Hugo_Symbol": [
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                    "GENE1",
-                ],
-                "del_start": [
-                    480,
-                    481,
-                    481,
-                    483,
-                    484,
-                    485,
-                ],
-                "del_end": [
-                    485,
-                    482,
-                    482,
-                    484,
-                    485,
-                    485,
-                ],
-                "PATIENT_ID": [
-                    "patient_1",
-                    "patient_1",
-                    "patient_2",
-                    "patient_3",
-                    "patient_4",
-                    "patient_5",
-                ],
+                "HGVSp": [
+                    "p.Asp359_Thr364delinsGlyArgAla",
+                    "p.Gln367_Gln379del",
+                    "p.Leu370del",
+                ]
             }
         )
-
-        result = utils.counting.count_patients_with_nested_deletions(df)
-
+        result = utils.counting.add_deletion_positions(df, source="HGVSp")
         expected = pl.from_dict(
             {
-                "del_start": [480, 481, 483, 484, 485],
-                "del_end": [485, 482, 484, 485, 485],
-                "nested_patient_count": [5, 2, 1, 2, 1],
+                "HGVSp": [
+                    "p.Asp359_Thr364delinsGlyArgAla",
+                    "p.Gln367_Gln379del",
+                    "p.Leu370del",
+                ],
+                "del_start": [359, 367, 370],
+                "del_end": [364, 379, 370],
             }
         )
-
         assert_frame_equal(
             result, expected, check_column_order=False, check_row_order=False
         )
 
 
 class TestCountNestedInframeDeletionsAllCancers:
-    def test_count_nested_inframe_deletions_all_cancers(self):
+    def test_count_nested_inframe_deletions_all_cancers_one_transcript_per_gene(
+        self,
+    ):
         df = pl.from_dict(
             {
                 "Hugo_Symbol": [
@@ -874,6 +804,14 @@ class TestCountNestedInframeDeletionsAllCancers:
                     "GENE2",
                     "GENE3",
                     "GENE3",
+                ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript3",
+                    "Transcript3",
                 ],
                 "del_start": [
                     480,
@@ -915,6 +853,13 @@ class TestCountNestedInframeDeletionsAllCancers:
                     "GENE3",
                     "GENE3",
                 ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript3",
+                    "Transcript3",
+                ],
                 "del_start": [480, 481, 483, 484, 485],
                 "del_end": [485, 482, 484, 485, 485],
                 "NestedInframeDeletionsPerCDS.All_Cancers_Count_N_5000": [
@@ -931,9 +876,98 @@ class TestCountNestedInframeDeletionsAllCancers:
             result, expected, check_row_order=False, check_column_order=False
         )
 
+    def test_count_nested_inframe_deletions_all_cancers_multiple_transcripts_per_gene(
+        self,
+    ):
+        df = pl.from_dict(
+            {
+                "Hugo_Symbol": [
+                    "GENE1",
+                    "GENE1",
+                    "GENE1",
+                    "GENE2",
+                    "GENE3",
+                    "GENE3",
+                ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript3",
+                    "Transcript4",
+                    "Transcript4",
+                ],
+                "del_start": [
+                    480,
+                    481,
+                    481,
+                    483,
+                    484,
+                    485,
+                ],
+                "del_end": [
+                    485,
+                    482,
+                    482,
+                    484,
+                    485,
+                    485,
+                ],
+                "PATIENT_ID": [
+                    "patient_1",
+                    "patient_1",
+                    "patient_2",
+                    "patient_3",
+                    "patient_4",
+                    "patient_5",
+                ],
+            }
+        )
+
+        result = utils.counting.count_nested_inframe_deletions(
+            df, "All_Cancers", 5000
+        )
+
+        expected = pl.from_dict(
+            {
+                "Hugo_Symbol": [
+                    "GENE1",
+                    "GENE1",
+                    "GENE1",
+                    "GENE2",
+                    "GENE3",
+                    "GENE3",
+                ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript3",
+                    "Transcript4",
+                    "Transcript4",
+                ],
+                "del_start": [480, 481, 481, 483, 484, 485],
+                "del_end": [485, 482, 482, 484, 485, 485],
+                "NestedInframeDeletionsPerCDS.All_Cancers_Count_N_5000": [
+                    1,
+                    1,
+                    1,
+                    1,
+                    2,
+                    1,
+                ],
+            }
+        )
+
+        assert_frame_equal(
+            result, expected, check_row_order=False, check_column_order=False
+        )
+
 
 class TestCountNestedInframeDeletionsPerCancerType:
-    def test_count_nested_inframe_deletions_per_cancer_type(self):
+    def test_count_nested_inframe_deletions_per_cancer_type_one_transcript_per_gene(
+        self,
+    ):
         df = pl.from_dict(
             {
                 "Hugo_Symbol": [
@@ -943,6 +977,14 @@ class TestCountNestedInframeDeletionsPerCancerType:
                     "GENE1",
                     "GENE1",
                     "GENE1",
+                ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
                 ],
                 "del_start": [
                     480,
@@ -992,6 +1034,13 @@ class TestCountNestedInframeDeletionsPerCancerType:
         expected = pl.from_dict(
             {
                 "Hugo_Symbol": ["GENE1", "GENE1", "GENE1", "GENE1", "GENE1"],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                ],
                 "del_start": [480, 481, 483, 484, 485],
                 "del_end": [485, 482, 484, 485, 485],
                 "NestedInframeDeletionsPerCDS.Cancer 1_Count_N_500": [
@@ -1017,6 +1066,126 @@ class TestCountNestedInframeDeletionsPerCancerType:
                 ],
                 "NestedInframeDeletionsPerCDS.Cancer 4_Count_N_50": [
                     1,
+                    0,
+                    0,
+                    1,
+                    1,
+                ],
+                "NestedInframeDeletionsPerCDS.Cancer 5_Count_N_120": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            }
+        )
+
+        assert_frame_equal(
+            result, expected, check_row_order=False, check_column_order=False
+        )
+
+    def test_count_nested_inframe_deletions_per_cancer_type_multiple_transcripts_per_gene(
+        self,
+    ):
+        df = pl.from_dict(
+            {
+                "Hugo_Symbol": [
+                    "GENE1",
+                    "GENE1",
+                    "GENE1",
+                    "GENE1",
+                    "GENE1",
+                    "GENE1",
+                ],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript2",
+                ],
+                "del_start": [
+                    480,
+                    481,
+                    481,
+                    483,
+                    484,
+                    485,
+                ],
+                "del_end": [
+                    485,
+                    482,
+                    482,
+                    484,
+                    485,
+                    485,
+                ],
+                "PATIENT_ID": [
+                    "patient_1",
+                    "patient_1",
+                    "patient_2",
+                    "patient_3",
+                    "patient_4",
+                    "patient_5",
+                ],
+                "CANCER_TYPE": [
+                    "Cancer 1",
+                    "Cancer 1",
+                    "Cancer 2",
+                    "Cancer 3",
+                    "Cancer 1",
+                    "Cancer 4",
+                ],
+            }
+        )
+        per_patient_cancer_total = {
+            "Cancer 1": 500,
+            "Cancer 2": 4,
+            "Cancer 3": 3,
+            "Cancer 4": 50,
+            "Cancer 5": 120,
+        }
+        result = utils.counting.count_nested_inframe_deletions_per_cancer_type(
+            df, per_patient_cancer_total
+        )
+
+        expected = pl.from_dict(
+            {
+                "Hugo_Symbol": ["GENE1", "GENE1", "GENE1", "GENE1", "GENE1"],
+                "Transcript_ID": [
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript1",
+                    "Transcript2",
+                    "Transcript2",
+                ],
+                "del_start": [480, 481, 483, 484, 485],
+                "del_end": [485, 482, 484, 485, 485],
+                "NestedInframeDeletionsPerCDS.Cancer 1_Count_N_500": [
+                    1,
+                    1,
+                    0,
+                    1,
+                    0,
+                ],
+                "NestedInframeDeletionsPerCDS.Cancer 2_Count_N_4": [
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                ],
+                "NestedInframeDeletionsPerCDS.Cancer 3_Count_N_3": [
+                    1,
+                    0,
+                    1,
+                    0,
+                    0,
+                ],
+                "NestedInframeDeletionsPerCDS.Cancer 4_Count_N_50": [
+                    0,
                     0,
                     0,
                     1,

--- a/utils/aggregation.py
+++ b/utils/aggregation.py
@@ -130,7 +130,7 @@ def get_truncating_variants(df: pl.DataFrame) -> pl.DataFrame:
     return truncating
 
 
-def get_inframe_deletions(df: pl.DataFrame) -> pl.DataFrame:
+def get_inframe_deletions(df: pl.DataFrame, column_used: str) -> pl.DataFrame:
     """
     Get inframe deletions from the Polars DataFrame
 
@@ -138,6 +138,8 @@ def get_inframe_deletions(df: pl.DataFrame) -> pl.DataFrame:
     ----------
     df : pl.DataFrame
         DataFrame containing the Genie data
+    column_used : str
+        Column to check for non-null values, either 'HGVSc' or 'HGVSp'
 
     Returns
     -------
@@ -146,7 +148,7 @@ def get_inframe_deletions(df: pl.DataFrame) -> pl.DataFrame:
     """
     inframe_deletions = df.filter(
         pl.col("Variant_Classification") == "In_Frame_Del"
-    ).filter(pl.col("HGVSc").is_not_null())
+    ).filter(pl.col(column_used).is_not_null())
     return inframe_deletions
 
 

--- a/utils/aggregation.py
+++ b/utils/aggregation.py
@@ -126,6 +126,13 @@ def get_truncating_variants(df: pl.DataFrame) -> pl.DataFrame:
             )
         )
         & (pl.col("HGVSp").str.contains("Ter", literal=True, strict=False))
+    ).select(
+        "Hugo_Symbol",
+        "grch38_description",
+        "Transcript_ID",
+        "HGVSc",
+        "PATIENT_ID",
+        "CANCER_TYPE",
     )
     return truncating
 
@@ -146,9 +153,18 @@ def get_inframe_deletions(df: pl.DataFrame, column_used: str) -> pl.DataFrame:
     pl.DataFrame
         DataFrame with inframe deletion variants
     """
-    inframe_deletions = df.filter(
-        pl.col("Variant_Classification") == "In_Frame_Del"
-    ).filter(pl.col(column_used).is_not_null())
+    inframe_deletions = (
+        df.filter(pl.col("Variant_Classification") == "In_Frame_Del").filter(
+            pl.col(column_used).is_not_null()
+        )
+    ).select(
+        "grch38_description",
+        "Hugo_Symbol",
+        "Transcript_ID",
+        column_used,
+        "PATIENT_ID",
+        "CANCER_TYPE",
+    )
     return inframe_deletions
 
 

--- a/utils/merging.py
+++ b/utils/merging.py
@@ -54,13 +54,15 @@ def merge_truncating_variants_counts(
     # Get only unique truncating variants to add counts
     truncating_variants_no_dups = truncating_variants.unique(
         subset="grch38_description", keep="first"
-    ).select(["Hugo_Symbol", "grch38_description", "CDS_position"])
+    ).select(
+        ["Hugo_Symbol", "grch38_description", "Transcript_ID", "CDS_position"]
+    )
 
     # Merge the truncating variants with the counts
     merged_counts = multi_merge(
         truncating_variants_no_dups,
         [truncating_counts_all_cancers, truncating_counts_per_cancer],
-        on=["Hugo_Symbol", "CDS_position"],
+        on=["Hugo_Symbol", "Transcript_ID", "CDS_position"],
         how="left",
     )
 
@@ -96,22 +98,30 @@ def merge_inframe_deletions_with_counts(
     # Remove duplicates of the same variant and deletion start and ends
     inframe_with_positions_no_dups = inframe_deletions_with_positions.unique(
         subset="grch38_description", keep="first"
-    ).select(["Hugo_Symbol", "grch38_description", "del_start", "del_end"])
+    ).select(
+        [
+            "Hugo_Symbol",
+            "Transcript_ID",
+            "grch38_description",
+            "del_start",
+            "del_end",
+        ]
+    )
 
     # Merge the inframe deletion counts together
     merged_counts = multi_merge(
         inframe_deletions_count_all_cancers,
         [inframe_deletions_count_per_cancer],
-        on=["Hugo_Symbol", "del_start", "del_end"],
+        on=["Hugo_Symbol", "Transcript_ID", "del_start", "del_end"],
         how="left",
     )
 
     # Merge the unique inframe deletions with the counts
     inframe_deletions_with_counts = inframe_with_positions_no_dups.join(
         merged_counts,
-        on=["Hugo_Symbol", "del_start", "del_end"],
+        on=["Hugo_Symbol", "Transcript_ID", "del_start", "del_end"],
         how="left",
-    ).drop(["Hugo_Symbol", "del_start", "del_end"])
+    ).drop(["Hugo_Symbol", "Transcript_ID", "del_start", "del_end"])
 
     return inframe_deletions_with_counts
 


### PR DESCRIPTION
- Consider `Transcript_ID` when doing truncating and inframe deletion counts in `counting.py`, as some genes have multiple transcripts
  - Update unit tests to include transcript
- New input to `generate_count_data.py` to specify whether to extract the positions for inframe deletions from the HGVSc or HGVSp
  - Update name of inframe deletions counts to be "perCDS" or "perAA"
  - Update unit tests
- Do selecting / dropping of columns within functions to tidy up main function
  - Update unit tests with necessary columns
- Rewrite downstream truncating / inframe deletion counts as polars doesn't allow grouping by multiple columns and using apply