### PR TITLE
DI-12766 Do not write INFO fields with counts of 0 to VCF

### DIFF
--- a/convert_counts_to_vcf.py
+++ b/convert_counts_to_vcf.py
@@ -317,16 +317,16 @@ def write_variants_to_vcf(
             if value is None or value == "":
                 continue
 
-            # Skip zero, including "0", 0, 0.0, np.int64(0) etc
+            # Skip zero/NaN for numeric-like values
+            numeric_value = None
             try:
-                if float(value) == 0:
-                    continue
-            except Exception:
-                pass
+                numeric_value = float(value)
+            except (TypeError, ValueError):
+                numeric_value = None
 
-            # Skip NaN
-            if isinstance(value, float) and math.isnan(value):
-                continue
+            if numeric_value is not None:
+                if numeric_value == 0 or math.isnan(numeric_value):
+                    continue
 
             try:
                 formatted_info_fields[field_name] = converter(value)

--- a/convert_counts_to_vcf.py
+++ b/convert_counts_to_vcf.py
@@ -1,5 +1,6 @@
 import argparse
 import math
+import numbers
 import polars as pl
 import pysam
 import re
@@ -311,13 +312,22 @@ def write_variants_to_vcf(
         formatted_info_fields = {}
         for field_name, converter in field_converters.items():
             value = row.get(field_name)
-            if (
-                value is None
-                or value == ""
-                or (isinstance(value, (int, float)) and value == 0)
-                or (isinstance(value, float) and math.isnan(value))
-            ):
+
+            # Skip missing
+            if value is None or value == "":
                 continue
+
+            # Skip zero, including "0", 0, 0.0, np.int64(0) etc
+            try:
+                if float(value) == 0:
+                    continue
+            except Exception:
+                pass
+
+            # Skip NaN
+            if isinstance(value, float) and math.isnan(value):
+                continue
+
             try:
                 formatted_info_fields[field_name] = converter(value)
             except Exception as err:


### PR DESCRIPTION
- To make the VCF smaller, we are not writing out any counts which are 0 to INFO fields - fix this functionality

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/Genie/12)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or empty INFO values in VCF output: nulls, empty strings, zeros and NaN are now consistently filtered to prevent spurious entries and ensure output integrity; overall behaviour and error handling remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->